### PR TITLE
add buffer formatcmd

### DIFF
--- a/filetype/vlang.kak
+++ b/filetype/vlang.kak
@@ -25,6 +25,7 @@ hook global BufSetOption filetype=(vlang) %{
     set-option buffer comment_line '//'
     set-option buffer comment_block_begin '/*'
     set-option buffer comment_block_end '*/'
+    set-option buffer formatcmd 'v fmt'
 }
 
 hook -group vlang-highlight global WinSetOption filetype=vlang %{


### PR DESCRIPTION
Thanks for this. Small addition -

``` sh
:format
```

allows formatting the buffer using v fmt.